### PR TITLE
Fixed the API paths after the breaking change in 7.0.2

### DIFF
--- a/Documentation/Extending-Umbraco/Property-Editors/creating-tutorial4-v7.md
+++ b/Documentation/Extending-Umbraco/Property-Editors/creating-tutorial4-v7.md
@@ -84,7 +84,7 @@ Inside the GetAll() method, we now write a bit of code, that connects to the dat
 	//fetch data from DB with the query and map to Person object
 	return db.Fetch<Person>(query);
 
-We are now done with the server-side of things, with the file saved in app_code you can now open the Url: /umbraco/My/PersonApi/GetAll
+We are now done with the server-side of things, with the file saved in app_code you can now open the Url: /umbraco/backoffice/My/PersonApi/GetAll
 
 This will return our json code.
 
@@ -100,7 +100,7 @@ Create a new file as `person.resource.js` and add:
 		    return {
 		        //this cals the Api Controller we setup earlier
 		        getAll: function () {
-		            return  $http.get("My/PersonApi/GetAll");
+		            return  $http.get("backoffice/My/PersonApi/GetAll");
 		        }
 		    };
 		}
@@ -139,7 +139,7 @@ With this, the entire flow is:
 
 1. the view renders a list of people with a controller
 2. the controller asks the personResource for data
-3. the personResource returns a promise and asks the /my/PersonAPI api controller
+3. the personResource returns a promise and asks the my/PersonAPI api controller
 4. The apicontroller queries the database, which returns the data as strongly typed Person objects
 5. the api controller returns those `Person` objects as json to the resource
 6. the resource resolve the promise

--- a/Documentation/Reference/WebApi/index.md
+++ b/Documentation/Reference/WebApi/index.md
@@ -64,9 +64,9 @@ Example:
 
 All locally declared Umbraco api controllers will be routed under the url path of:
 
-*~/Umbraco/Api/[YourControllerName]*
+*~/Umbraco/backoffice/Api/[YourControllerName]*
 
-E.g *~/Umbraco/Api/Products/GetAllProducts*
+E.g *~/Umbraco/backoffice/Api/Products/GetAllProducts*
 
 ###Plugin based controller
 
@@ -85,7 +85,7 @@ Example:
 
 Now this controller will be routed via the area called "AwesomeProducts". All plugin based Umbraco api controlleres will be routed under the url path of:
 
-*~/Umbraco/[YourAreaName]/[YourControllerName]*
+*~/Umbraco/backoffice/[YourAreaName]/[YourControllerName]*
 
 For more information about areas, Urls and routing see the [routing section](routing.md)
 


### PR DESCRIPTION
As discussed here: https://our.umbraco.org/forum/umbraco-7/using-umbraco-7/64690-Simple-package-not-available-TextValue-Dropdown-List?p=1#comment218791 and here: https://our.umbraco.org/forum/umbraco-7/developing-umbraco-7-packages/48668-Creating-an-UmbracoAuthorizedJsonController some of the documentation hasn't been updated after this change to start all API paths with "umbraco/backoffice" in 7.0.2 http://umbraco.com/follow-us/blog-archive/2014/1/17/heads-up,-breaking-change-coming-in-702-and-62.aspx. I've done that here, though not searched the rest of the documentation for any other places it might need to happen.