### PR TITLE
Corrected typo in "Checkbox list" section.

### DIFF
--- a/Getting-Started/Data/Data-Types/index.md
+++ b/Getting-Started/Data/Data-Types/index.md
@@ -7,7 +7,7 @@ Adds a list of approved colours which can be selected by clicking. The approved 
 as hex values (without the #) in the prevalues field. i.e. cccccc
 ####Checkbox list####
 Displays a list of preset values as a list of checkbox controls. The preset values are modified in the developer 
-section under "data types" / checkbox list where new items can be added. The value saved is a commasepareted 
+section under "data types" / checkbox list where new items can be added. The value saved is a comma-separated 
 string of prevalue IDs, which is easiliest processed with xslt. (umbraco.library:GetPrevalue())
 ####Content picker####
 The content picker opens a simple modal to pick a specific page from the content structure. 


### PR DESCRIPTION
Changed "commasepareted" to "comma-separated" in the "Checkbox list" section.